### PR TITLE
Fixed link up detection

### DIFF
--- a/external_libs/lwip/port/FreeRTOS/spiif.c
+++ b/external_libs/lwip/port/FreeRTOS/spiif.c
@@ -29,6 +29,29 @@ void spi_if_clr(void) {
   setSIR(0);
 }
 
+/**
+ * Checks PHYCFGR for the hardware link state, and calls lwIP's
+ * netif_set_link_up() and netif_set_link_down() functions as needed.
+ */
+static void spi_if_check_link_state(void)
+{
+	static bool linkstate;
+
+	// Bit 0 is link status (1 = up), 1 is speed (1 = 100), 2 is duplex (1 = full)
+	volatile uint8_t phyReg = getPHYCFGR();
+	linkstate = phyReg & (1 << 0);
+	if (linkstate && !netif_is_link_up(spi_if_netif))
+	{
+		debug_print("ETH0 Hardware link up\r\n");
+		netif_set_link_up(spi_if_netif);
+	}
+	else if (!linkstate && netif_is_link_up(spi_if_netif))
+	{
+		debug_print("ETH0 Hardware link down\r\n");
+		netif_set_link_down(spi_if_netif);
+	}
+}
+
 void spi_if_input(void * pvParameters) {
   err_t result;
   struct pbuf *p = NULL;
@@ -37,18 +60,16 @@ void spi_if_input(void * pvParameters) {
   bool linkstate;
 
   for ( ;; ) {
-    if (xSemaphoreTake(s_xSemaphoreSpi, 500) != pdTRUE) {
+    if (xSemaphoreTake(s_xSemaphoreSpi, pdMS_TO_TICKS(500)) != pdTRUE) {
       spi_if_clr();
-      volatile uint8_t phyReg= getPHYCFGR();
-      linkstate= phyReg & (1 << 0);
-      if (linkstate && !netif_is_link_up(spi_if_netif)) {
-        netif_set_link_up(spi_if_netif);
-      }
-      else if (!linkstate && netif_is_link_up(spi_if_netif)) {
-        netif_set_link_down(spi_if_netif);
-      }
+      spi_if_check_link_state();
     }
     else {
+ 			if (!netif_is_link_up(spi_if_netif))
+			{
+				// Link must have come back up - need to check
+				spi_if_check_link_state();
+			}
 GET_NEXT_FRAGMENT:
       spi_if_clr();
       res= wiz_read_receive_pbuf(&p);

--- a/external_libs/lwip/port/FreeRTOS/spiif.c
+++ b/external_libs/lwip/port/FreeRTOS/spiif.c
@@ -42,12 +42,10 @@ static void spi_if_check_link_state(void)
 	linkstate = phyReg & (1 << 0);
 	if (linkstate && !netif_is_link_up(spi_if_netif))
 	{
-		debug_print("ETH0 Hardware link up\r\n");
 		netif_set_link_up(spi_if_netif);
 	}
 	else if (!linkstate && netif_is_link_up(spi_if_netif))
 	{
-		debug_print("ETH0 Hardware link down\r\n");
 		netif_set_link_down(spi_if_netif);
 	}
 }


### PR DESCRIPTION
Fixed problem with "link up" transition being missed when network traffic is present. Previously it would never check the hardware link state as long as a packet was received within the timeout interval, leaving outbound packets unable to be sent.

Also modified the xSemaphoreTake() call to use the pdMS_TO_TICKS macro so the timeout value has more meaning. There's no way of knowing what the original intended timeout duration was.